### PR TITLE
feat: Add loading spinner to submit button

### DIFF
--- a/dev.log
+++ b/dev.log
@@ -1,3 +1,0 @@
-
-> nextn@0.1.0 dev
-> next dev --turbopack -p 9002

--- a/src/components/outfit-rater.tsx
+++ b/src/components/outfit-rater.tsx
@@ -108,7 +108,7 @@ export function OutfitRater() {
             </div>
           )}
 
-          <SubmitButton className="w-full" pendingText="Rating...">Rate My Outfit</SubmitButton>
+          <SubmitButton className="w-full" pendingText="Rating..." pending={state.status === 'loading'}>Rate My Outfit</SubmitButton>
         </form>
 
         {state.status === 'success' && state.result && (

--- a/src/components/submit-button.tsx
+++ b/src/components/submit-button.tsx
@@ -7,10 +7,12 @@ import { Loader2 } from 'lucide-react';
 
 type Props = ButtonProps & {
     pendingText?: string;
+    pending?: boolean;
 };
 
-export function SubmitButton({ children, pendingText, ...props }: Props) {
-  const { pending } = useFormStatus();
+export function SubmitButton({ children, pendingText, pending: pendingProp, ...props }: Props) {
+  const { pending: formStatusPending } = useFormStatus();
+  const pending = pendingProp !== undefined ? pendingProp : formStatusPending;
 
   return (
     <Button {...props} type="submit" disabled={pending} aria-disabled={pending}>


### PR DESCRIPTION
This commit adds a loading spinner to the SubmitButton component.

The spinner is displayed when the button is in a pending state, providing visual feedback to the user during an API call.

The SubmitButton component has been updated to accept a 'pending' prop to allow its state to be controlled from the parent component.

The OutfitRater component now uses this 'pending' prop to show the spinner while the outfit is being rated.