### PR TITLE
feat: Add loading spinners to all feature buttons

### DIFF
--- a/dev.log
+++ b/dev.log
@@ -1,0 +1,3 @@
+
+> nextn@0.1.0 dev
+> next dev --turbopack -p 9002

--- a/src/components/hairstyle-helper.tsx
+++ b/src/components/hairstyle-helper.tsx
@@ -128,7 +128,7 @@ export function HairstyleHelper() {
             </div>
           )}
 
-          <SubmitButton className="w-full" pendingText="Analyzing...">Suggest Hairstyles</SubmitButton>
+          <SubmitButton className="w-full" pendingText="Analyzing..." pending={state.status === 'loading'}>Suggest Hairstyles</SubmitButton>
         </form>
 
         {state.status === 'success' && state.result && (

--- a/src/components/style-guide.tsx
+++ b/src/components/style-guide.tsx
@@ -201,7 +201,7 @@ export function StyleGuide() {
                 )}
             </TabsContent>
         </Tabs>
-        <SubmitButton className="w-full mt-4" pendingText={activeTab === 'manual' ? "Generating..." : "Analyzing..."}>Get My Style Guide</SubmitButton>
+        <SubmitButton className="w-full mt-4" pendingText={activeTab === 'manual' ? "Generating..." : "Analyzing..."} pending={state.status === 'loading'}>Get My Style Guide</SubmitButton>
         </form>
 
         {(state.status === 'success' && state.result) && (


### PR DESCRIPTION
This commit extends the loading spinner functionality to all feature submission buttons, including the Hairstyle Helper and Style Guide.

The 'pending' prop is now passed to the SubmitButton in all relevant components to ensure a consistent user experience, providing visual feedback during API calls.